### PR TITLE
Add basic support for heredocs

### DIFF
--- a/grammars/puppet.cson
+++ b/grammars/puppet.cson
@@ -233,6 +233,39 @@
         'include': '#variable'
       }
     ]
+  'plain-heredoc':
+    'begin': '(@\\(([^ ()/:\\n\\r]+)(/[nrts$uL]*)?\\))'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.string.begin.puppet'
+    'end': '^((\\s*\\|\\s*)?(\\s*-\\s*)?(\\2)$)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.string.end.puppet'
+    'name': 'string.quoted.single.puppet'
+    'patterns': [
+      {
+        'include': '#escaped_char'
+      }
+    ]
+  'double-quoted-heredoc':
+    'begin': '(@\\("([^ ()/:\\n\\r]+)"(/[nrts$uL]*)?\\))'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.string.begin.puppet'
+    'end': '^((\\s*\\|\\s*)?(\\s*-\\s*)?(\\2)$)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.string.end.puppet'
+    'name': 'string.quoted.double.puppet'
+    'patterns': [
+      {
+        'include': '#escaped_char'
+      }
+      {
+        'include': '#variable'
+      }
+    ]
   'escaped_char':
     'match': '\\\\.'
     'name': 'constant.character.escape.puppet'
@@ -427,6 +460,12 @@
     ]
   'strings':
     'patterns': [
+      {
+        'include': '#double-quoted-heredoc'
+      }
+      {
+        'include': '#plain-heredoc'
+      }
       {
         'include': '#double-quoted-string'
       }

--- a/spec/puppet-spec.coffee
+++ b/spec/puppet-spec.coffee
@@ -97,3 +97,12 @@ describe "Puppet grammar", ->
 
       {tokens} = grammar.tokenizeLine("package {'foo':}")
       expect(tokens[0]).toEqual value: 'package', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'storage.type.puppet']
+
+  describe "heredocs", ->
+    it "tokenizes plain heredocs as single-quoted strings", ->
+      {tokens} = grammar.tokenizeLine("@(HEREDOC)")
+      expect(tokens[0]).toEqual value: '@(HEREDOC)', scopes: ['source.puppet', 'string.quoted.single.puppet', 'punctuation.definition.string.begin.puppet']
+
+    it "tokenizes double-quoted heredocs as double-quoted strings", ->
+      {tokens} = grammar.tokenizeLine('@("HEREDOC")')
+      expect(tokens[0]).toEqual value: '@("HEREDOC")', scopes: ['source.puppet', 'string.quoted.double.puppet', 'punctuation.definition.string.begin.puppet']


### PR DESCRIPTION
Trying to match the syntax as closely as possible, given the description:

https://docs.puppet.com/puppet/4.9/lang_data_string.html#heredocs

Plain heredocs as well as double quoted heredocs (allowing interpolation)
should be supported. However, this grammar doesn't yet consider which escape
sequences are enabled or not in the given flags.